### PR TITLE
feat: enhance canvas interactivity

### DIFF
--- a/neo-modelo/src/canvas/Canvas.tsx
+++ b/neo-modelo/src/canvas/Canvas.tsx
@@ -1,5 +1,5 @@
 import { Stage, Layer, Line } from "react-konva";
-import { useRef, useState, useCallback } from "react";
+import { useRef, useState, useCallback, useLayoutEffect } from "react";
 import { useERStore } from "@/core/store";
 import { EntityNode } from "./nodes/EntityNode";
 import { RelationshipNode } from "./nodes/RelationshipNode";
@@ -15,6 +15,7 @@ import { Switch } from "@/components/ui/switch";
 import { useTheme } from "@/theme/useTheme";
 import type { KonvaEventObject } from "konva/lib/Node";
 import type { Stage as StageType } from "konva/lib/Stage";
+import { Plus, Trash2 } from "lucide-react";
 
 export const stageRefGlobal: { current: StageType | null } = { current: null };
 
@@ -51,16 +52,23 @@ export function Canvas() {
   const { theme } = useTheme();
 
   const stageRef = useRef<StageType | null>(null);
-  stageRefGlobal.current = stageRef.current;
+  useLayoutEffect(() => {
+    stageRefGlobal.current = stageRef.current;
+  });
 
   const [dragStart, setDragStart] = useState<{ x: number; y: number } | null>(null);
-  const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+  const [menu, setMenu] = useState<{ id: string; kind: string; x: number; y: number } | null>(null);
   const [attrParent, setAttrParent] = useState<string | null>(null);
   const [attrName, setAttrName] = useState("");
   const [attrDomain, setAttrDomain] = useState("");
   const [attrMulti, setAttrMulti] = useState(false);
   const [attrOpt, setAttrOpt] = useState(false);
   const [attrKey, setAttrKey] = useState(false);
+  const [connection, setConnection] = useState<{ from: string; start: { x: number; y: number }; end: { x: number; y: number } } | null>(null);
+
+  const startConnect = (id: string, start: { x: number; y: number }) => {
+    setConnection({ from: id, start, end: start });
+  };
 
   const onWheel = useCallback((e: KonvaEventObject<WheelEvent>) => {
     e.evt.preventDefault();
@@ -74,20 +82,49 @@ export function Canvas() {
   }, [viewport.scale, viewport.offset.x, viewport.offset.y, setViewport]);
 
   const onMouseDown = (e: KonvaEventObject<MouseEvent>) => {
-    if (e.target === e.target.getStage()) {
+    if (e.target === e.target.getStage() && !connection) {
       setDragStart({ x: e.evt.clientX, y: e.evt.clientY });
       clearSelection();
     }
   };
   const onMouseMove = (e: KonvaEventObject<MouseEvent>) => {
+    if (connection) {
+      const pos = stageRef.current?.getPointerPosition();
+      if (pos) setConnection(c => c ? { ...c, end: pos } : null);
+      return;
+    }
     if (!dragStart) return;
     const dx = e.evt.clientX - dragStart.x, dy = e.evt.clientY - dragStart.y;
     setDragStart({ x: e.evt.clientX, y: e.evt.clientY });
     setViewport(viewport.scale, { x: viewport.offset.x + dx, y: viewport.offset.y + dy });
   };
-  const onMouseUp = () => setDragStart(null);
+  const onMouseUp = () => {
+    if (connection) {
+      const pos = stageRef.current?.getPointerPosition();
+      if (pos) {
+        const target = useERStore.getState().nodes.find(n => {
+          const dx = n.pos.x - pos.x;
+          const dy = n.pos.y - pos.y;
+          return Math.hypot(dx, dy) < 30 && n.id !== connection.from;
+        });
+        if (target) connect(connection.from, target.id);
+      }
+      setConnection(null);
+      return;
+    }
+    setDragStart(null);
+  };
 
-  const w = window.innerWidth, h = window.innerHeight;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState({ w: 0, h: 0 });
+  useLayoutEffect(() => {
+    const update = () => {
+      if (containerRef.current) setSize({ w: containerRef.current.clientWidth, h: containerRef.current.clientHeight });
+    };
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
 
   const gridColor = theme === "dark" ? "#3f3f46" : "#e5e7eb";
 
@@ -106,23 +143,23 @@ export function Canvas() {
   };
 
   return (
-    <div className="h-full w-full relative">
+    <div ref={containerRef} className="h-full w-full relative overflow-hidden">
       <Stage
         ref={stageRef}
-        width={w} height={h}
+        width={size.w} height={size.h}
         x={viewport.offset.x} y={viewport.offset.y}
         scaleX={viewport.scale} scaleY={viewport.scale}
         perfectDrawEnabled={false}
         imageSmoothingEnabled={false}
         onWheel={onWheel} onMouseDown={onMouseDown} onMouseMove={onMouseMove} onMouseUp={onMouseUp}
       >
-        {showGrid && <GridLayer width={w} height={h} offset={viewport.offset} scale={viewport.scale} color={gridColor} />}
+        {showGrid && <GridLayer width={size.w} height={size.h} offset={viewport.offset} scale={viewport.scale} color={gridColor} />}
 
         <Layer>
           {edges.map((e) => (
             <DefaultEdge key={e.id} edge={e} nodes={nodes} onContextMenu={(evt: KonvaEventObject<MouseEvent>) => {
               evt.evt.preventDefault();
-              setMenu({ id: e.id, x: evt.evt.clientX, y: evt.evt.clientY });
+              setMenu({ id: e.id, kind: "edge", x: evt.evt.clientX, y: evt.evt.clientY });
             }} />
           ))}
         </Layer>
@@ -131,24 +168,45 @@ export function Canvas() {
           {nodes.map((n) => {
             const handler = (evt: KonvaEventObject<MouseEvent>) => {
               evt.evt.preventDefault();
-              setMenu({ id: n.id, x: evt.evt.clientX, y: evt.evt.clientY });
+              setMenu({ id: n.id, kind: n.kind, x: evt.evt.clientX, y: evt.evt.clientY });
             };
             switch (n.kind) {
-              case "entity": return <EntityNode key={n.id} node={n} onContextMenu={handler} />;
-              case "relationship": return <RelationshipNode key={n.id} node={n} onContextMenu={handler} />;
-              case "attribute": return <AttributeNode key={n.id} node={n} draggable={true} />;
+              case "entity": return <EntityNode key={n.id} node={n} onContextMenu={handler} onStartConnect={startConnect} />;
+              case "relationship": return <RelationshipNode key={n.id} node={n} onContextMenu={handler} onStartConnect={startConnect} />;
+              case "attribute": return <AttributeNode key={n.id} node={n} draggable={true} onStartConnect={startConnect} />;
               default: return null;
             }
           })}
         </Layer>
+
+        {connection && (
+          <Layer listening={false}>
+            <Line points={[connection.start.x, connection.start.y, connection.end.x, connection.end.y]} stroke="#2563eb" dash={[4,4]} />
+          </Layer>
+        )}
       </Stage>
 
       {showMinimap && <div className="absolute top-2 right-2 border border-border rounded bg-background/80"><MiniMap /></div>}
 
       {menu && (
         <ContextMenu open onOpenChange={() => setMenu(null)}>
-          <ContextMenuContent style={{ position: "absolute", top: menu.y, left: menu.x }} className="w-40">
-            <ContextMenuItem onSelect={() => { setAttrParent(menu.id); setMenu(null); }}>Adicionar atributos</ContextMenuItem>
+          <ContextMenuContent style={{ position: "absolute", top: menu.y, left: menu.x }} className="w-48">
+            {(menu.kind === "entity" || menu.kind === "relationship") && (
+              <ContextMenuItem onSelect={() => { setAttrParent(menu.id); setMenu(null); }}>
+                <Plus className="mr-2 h-4 w-4" /> Adicionar atributos
+              </ContextMenuItem>
+            )}
+            <ContextMenuItem onSelect={() => {
+              if (menu.kind === "edge") {
+                useERStore.getState().setSelection([], [menu.id]);
+              } else {
+                useERStore.getState().setSelection([menu.id]);
+              }
+              useERStore.getState().deleteSelected();
+              setMenu(null);
+            }}>
+              <Trash2 className="mr-2 h-4 w-4" /> Deletar
+            </ContextMenuItem>
           </ContextMenuContent>
         </ContextMenu>
       )}
@@ -174,7 +232,7 @@ export function Canvas() {
               <Label htmlFor="attr-key">Identificador</Label>
             </div>
             <div className="flex justify-end pt-2">
-              <Button onClick={handleAddAttr}>Adicionar</Button>
+              <Button onClick={handleAddAttr} className="gap-2"><Plus className="h-4 w-4" /> Adicionar</Button>
             </div>
           </div>
         </DialogContent>

--- a/neo-modelo/src/canvas/MiniMap.tsx
+++ b/neo-modelo/src/canvas/MiniMap.tsx
@@ -1,6 +1,7 @@
 import { Stage, Layer, Line, Rect, Circle } from "react-konva";
 import { useERStore } from "@/core/store";
 import { useTheme } from "@/theme/useTheme";
+import { stageRefGlobal } from "./Canvas";
 
 export function MiniMap() {
   const nodes = useERStore(s => s.nodes);
@@ -34,11 +35,10 @@ export function MiniMap() {
         {nodes.map(n => {
           switch (n.kind) {
             case "entity": {
-              return <Rect key={n.id} x={n.pos.x - 50} y={n.pos.y - 25} width={100} height={50} cornerRadius={6} stroke={stroke} />;
+              return <Rect key={n.id} x={n.pos.x - 50} y={n.pos.y - 25} width={100} height={50} stroke={stroke} />;
             }
             case "relationship": {
-              const S = 40;
-              const d = [0, -S / 2, S / 2, 0, 0, S / 2, -S / 2, 0];
+              const W = 60, H = 40; const d = [0, -H / 2, W / 2, 0, 0, H / 2, -W / 2, 0];
               return <Line key={n.id} x={n.pos.x} y={n.pos.y} points={d} closed stroke={stroke} />;
             }
             case "attribute": {
@@ -48,6 +48,15 @@ export function MiniMap() {
               return null;
           }
         })}
+      </Layer>
+      <Layer>
+        {(() => {
+          const stage = stageRefGlobal.current;
+          if (!stage) return null;
+          const vw = stage.width() / viewport.scale;
+          const vh = stage.height() / viewport.scale;
+          return <Rect x={-viewport.offset.x} y={-viewport.offset.y} width={vw} height={vh} stroke={"#2563eb"} />;
+        })()}
       </Layer>
     </Stage>
   );

--- a/neo-modelo/src/canvas/edges/DefaultEdge.tsx
+++ b/neo-modelo/src/canvas/edges/DefaultEdge.tsx
@@ -30,6 +30,7 @@ export function DefaultEdge({ edge, nodes, onContextMenu }: { edge: Edge; nodes:
           y={mid.y + 6}
           text={[edge.cardinality ?? "", edge.participation ?? ""].filter(Boolean).join(" / ")}
           fontSize={12}
+          fontFamily="var(--font-sans)"
           fill={theme === "dark" ? "#e5e7eb" : "#111"}
         />
       )}

--- a/neo-modelo/src/canvas/nodes/AttributeNode.tsx
+++ b/neo-modelo/src/canvas/nodes/AttributeNode.tsx
@@ -7,7 +7,7 @@ import { useTheme } from "@/theme/useTheme";
 const GRID = 20;
 
 /** Attribute circle with label to the side. */
-function AttributeNodeBase({ node, draggable = true }: { node: A; draggable?: boolean }) {
+function AttributeNodeBase({ node, draggable = true, onStartConnect }: { node: A; draggable?: boolean; onStartConnect?: (id: string, pos: { x: number; y: number }) => void }) {
   const setNodePos = useERStore((s) => s.setNodePos);
   const setSelection = useERStore((s) => s.setSelection);
   const connect = useERStore((s) => s.connect);
@@ -54,9 +54,13 @@ function AttributeNodeBase({ node, draggable = true }: { node: A; draggable?: bo
         text={node.name}
         x={R + 6}
         y={-6}
-        fontFamily="Inter, sans-serif"
+        fontFamily="var(--font-sans)"
         fill={theme === "dark" ? "#e5e7eb" : "#111"}
       />
+
+      {[{x:0,y:-R},{x:R,y:0},{x:0,y:R},{x:-R,y:0}].map((a,i)=>(
+        <Circle key={i} x={a.x} y={a.y} radius={4} fill={theme === "dark" ? "#27272a" : "#fff"} stroke="#2563eb" onMouseDown={(e)=>{e.cancelBubble=true; onStartConnect?.(node.id,{x:node.pos.x + a.x,y:node.pos.y + a.y});}} />
+      ))}
     </Group>
   );
 }

--- a/neo-modelo/src/canvas/nodes/EntityNode.tsx
+++ b/neo-modelo/src/canvas/nodes/EntityNode.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { Group, Rect, Text } from "react-konva";
+import { Group, Rect, Text, Circle } from "react-konva";
 import { useERStore } from "@/core/store";
 import type { EntityNode as E } from "@/core/types";
 import { useTheme } from "@/theme/useTheme";
@@ -8,7 +8,7 @@ import type { KonvaEventObject } from "konva/lib/Node";
 const GRID = 20;
 
 /** Entity rectangle with optional double border when weak. */
-function EntityNodeBase({ node, onContextMenu, draggable = true }: { node: E; onContextMenu?: (e: KonvaEventObject<MouseEvent>) => void; draggable?: boolean }) {
+function EntityNodeBase({ node, onContextMenu, draggable = true, onStartConnect }: { node: E; onContextMenu?: (e: KonvaEventObject<MouseEvent>) => void; draggable?: boolean; onStartConnect?: (id: string, pos: { x: number; y: number }) => void }) {
   const setNodePos = useERStore((s) => s.setNodePos);
   const setSelection = useERStore((s) => s.setSelection);
   const connect = useERStore((s) => s.connect);
@@ -43,30 +43,40 @@ function EntityNodeBase({ node, onContextMenu, draggable = true }: { node: E; on
       }}
     >
       <Rect
+        x={-W/2}
+        y={-H/2}
         width={W}
         height={H}
-        cornerRadius={6}
         fill={theme === "dark" ? "#27272a" : "#fff"}
         stroke={node.selected ? "#2563eb" : theme === "dark" ? "#e5e7eb" : "#111"}
         strokeWidth={node.selected ? 2 : 1}
       />
       <Text
         text={node.name}
-        x={8}
-        y={H / 2 - 8}
-        fontFamily="Inter, sans-serif"
+        x={-W/2}
+        y={-H/2}
+        width={W}
+        height={H}
+        align="center"
+        verticalAlign="middle"
+        fontFamily="var(--font-sans)"
         fill={theme === "dark" ? "#e5e7eb" : "#111"}
       />
       {node.weak && (
         <Rect
+          x={-W/2}
+          y={-H/2}
           width={W}
           height={H}
-          cornerRadius={6}
           listening={false}
           stroke={theme === "dark" ? "#e5e7eb" : "#111"}
           strokeWidth={1}
         />
       )}
+
+      {[{x:0,y:-H/2},{x:W/2,y:0},{x:0,y:H/2},{x:-W/2,y:0}].map((a,i)=>(
+        <Circle key={i} x={a.x} y={a.y} radius={4} fill={theme === "dark" ? "#27272a" : "#fff"} stroke="#2563eb" onMouseDown={(e)=>{e.cancelBubble=true; onStartConnect?.(node.id,{x:node.pos.x + a.x,y:node.pos.y + a.y});}} />
+      ))}
     </Group>
   );
 }

--- a/neo-modelo/src/canvas/nodes/RelationshipNode.tsx
+++ b/neo-modelo/src/canvas/nodes/RelationshipNode.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { Group, Line, Text } from "react-konva";
+import { Group, Line, Text, Circle } from "react-konva";
 import { useERStore } from "@/core/store";
 import type { RelationshipNode as R } from "@/core/types";
 import { useTheme } from "@/theme/useTheme";
@@ -8,15 +8,16 @@ import type { KonvaEventObject } from "konva/lib/Node";
 const GRID = 20;
 
 /** Diamond shape for relationship; double outline when identifying. */
-function RelationshipNodeBase({ node, onContextMenu, draggable = true }: { node: R; onContextMenu?: (e: KonvaEventObject<MouseEvent>) => void; draggable?: boolean }) {
+function RelationshipNodeBase({ node, onContextMenu, draggable = true, onStartConnect }: { node: R; onContextMenu?: (e: KonvaEventObject<MouseEvent>) => void; draggable?: boolean; onStartConnect?: (id: string, pos: { x: number; y: number }) => void }) {
   const setNodePos = useERStore((s) => s.setNodePos);
   const setSelection = useERStore((s) => s.setSelection);
   const connect = useERStore((s) => s.connect);
   const snap = useERStore((s) => s.settings.snap);
   const { theme } = useTheme();
 
-  const S = Math.max(80, node.name.length * 9);
-  const diamond = [0, -S / 2, S / 2, 0, 0, S / 2, -S / 2, 0];
+  const W = Math.max(120, node.name.length * 10);
+  const H = W * 0.6;
+  const diamond = [0, -H / 2, W / 2, 0, 0, H / 2, -W / 2, 0];
 
   return (
     <Group
@@ -51,12 +52,20 @@ function RelationshipNodeBase({ node, onContextMenu, draggable = true }: { node:
       />
       <Text
         text={node.name}
-        x={-S / 2 + 8}
-        y={-10}
-        fontFamily="Inter, sans-serif"
+        x={-W / 2}
+        y={-H / 2}
+        width={W}
+        height={H}
+        align="center"
+        verticalAlign="middle"
+        fontFamily="var(--font-sans)"
         fill={theme === "dark" ? "#e5e7eb" : "#111"}
       />
       {node.identifying && <Line points={diamond.map((v) => v * 0.9)} closed stroke={theme === "dark" ? "#e5e7eb" : "#111"} />}
+
+      {[{x:0,y:-H/2},{x:W/2,y:0},{x:0,y:H/2},{x:-W/2,y:0}].map((a,i)=>(
+        <Circle key={i} x={a.x} y={a.y} radius={4} fill={theme === "dark" ? "#27272a" : "#fff"} stroke="#2563eb" onMouseDown={(e)=>{e.cancelBubble=true; onStartConnect?.(node.id,{x:node.pos.x + a.x,y:node.pos.y + a.y});}} />
+      ))}
     </Group>
   );
 }

--- a/neo-modelo/src/ui/Toolbar.tsx
+++ b/neo-modelo/src/ui/Toolbar.tsx
@@ -4,6 +4,7 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { useERStore } from "@/core/store";
 import { ModeToggle } from "@/ui/ModeToggle";
+import { Square, Diamond, Circle as CircleIcon, ZoomIn, ZoomOut, Grid as GridIcon, Magnet, Map as MapIcon } from "lucide-react";
 
 export function Toolbar() {
   const addEntity = useERStore(s => s.addEntity);
@@ -24,28 +25,38 @@ export function Toolbar() {
   const zoom = (delta: number) => setViewport(viewport.scale * delta, viewport.offset);
 
   return (
-    <header className="h-11 w-full border-b border-border bg-background/60 backdrop-blur flex items-center px-2 gap-2">
-      <Button variant="outline" size="sm" onClick={() => spawn(addEntity)}>+ Entity</Button>
-      <Button variant="outline" size="sm" onClick={() => spawn(addRelationship)}>+ Relationship</Button>
-      <Button variant="outline" size="sm" onClick={() => spawn(addAttribute)}>+ Attribute</Button>
+    <header className="h-14 w-full border-b border-border bg-background/60 backdrop-blur flex items-center px-4 py-2 gap-3">
+      <Button variant="outline" size="sm" onClick={() => spawn(addEntity)} className="gap-1">
+        <Square className="h-4 w-4" /> Entity
+      </Button>
+      <Button variant="outline" size="sm" onClick={() => spawn(addRelationship)} className="gap-1">
+        <Diamond className="h-4 w-4" /> Relationship
+      </Button>
+      <Button variant="outline" size="sm" onClick={() => spawn(addAttribute)} className="gap-1">
+        <CircleIcon className="h-4 w-4" /> Attribute
+      </Button>
 
       <Separator orientation="vertical" className="mx-2 h-6" />
 
-      <Button variant="ghost" size="sm" onClick={() => zoom(1.1)}>Zoom +</Button>
-      <Button variant="ghost" size="sm" onClick={() => zoom(1/1.1)}>Zoom -</Button>
+      <Button variant="ghost" size="sm" onClick={() => zoom(1.1)} className="gap-1">
+        <ZoomIn className="h-4 w-4" /> Zoom +
+      </Button>
+      <Button variant="ghost" size="sm" onClick={() => zoom(1/1.1)} className="gap-1">
+        <ZoomOut className="h-4 w-4" /> Zoom -
+      </Button>
 
       <Separator orientation="vertical" className="mx-2 h-6" />
 
       <div className="flex items-center gap-1">
-        <Label htmlFor="grid" className="text-xs">Grid</Label>
+        <Label htmlFor="grid" className="text-xs flex items-center gap-1"><GridIcon className="h-3 w-3" /> Grid</Label>
         <Switch id="grid" checked={showGrid} onCheckedChange={toggleGrid} />
       </div>
       <div className="flex items-center gap-1">
-        <Label htmlFor="snap" className="text-xs">Snap</Label>
+        <Label htmlFor="snap" className="text-xs flex items-center gap-1"><Magnet className="h-3 w-3" /> Snap</Label>
         <Switch id="snap" checked={snap} onCheckedChange={toggleSnap} />
       </div>
       <div className="flex items-center gap-1">
-        <Label htmlFor="map" className="text-xs">Minimap</Label>
+        <Label htmlFor="map" className="text-xs flex items-center gap-1"><MapIcon className="h-3 w-3" /> Minimap</Label>
         <Switch id="map" checked={showMinimap} onCheckedChange={toggleMinimap} />
       </div>
 


### PR DESCRIPTION
## Summary
- allow infinite panning canvas and add connector anchors with live minimap
- center element text with shadcn font and widen relationship diamonds
- add icons and delete option to toolbar and context menus

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689cae37f2148328a77521e950358c72