### PR TITLE
feat: refine ui and minimap

### DIFF
--- a/neo-modelo/src/canvas/Canvas.tsx
+++ b/neo-modelo/src/canvas/Canvas.tsx
@@ -186,7 +186,11 @@ export function Canvas() {
         )}
       </Stage>
 
-      {showMinimap && <div className="absolute top-2 right-2 border border-border rounded bg-background/80"><MiniMap /></div>}
+      {showMinimap && (
+        <div className="absolute top-2 right-2 bg-muted/60">
+          <MiniMap />
+        </div>
+      )}
 
       {menu && (
         <ContextMenu open onOpenChange={() => setMenu(null)}>

--- a/neo-modelo/src/canvas/MiniMap.tsx
+++ b/neo-modelo/src/canvas/MiniMap.tsx
@@ -11,7 +11,7 @@ export function MiniMap() {
 
   const w = 200, h = 150;
   const scale = 0.2;
-  const stroke = theme === "dark" ? "#e5e7eb" : "#111";
+  const stroke = theme === "dark" ? "#a1a1aa" : "#6b7280";
 
   return (
     <Stage
@@ -19,8 +19,8 @@ export function MiniMap() {
       height={h}
       scaleX={scale}
       scaleY={scale}
-      x={-viewport.offset.x * scale}
-      y={-viewport.offset.y * scale}
+      x={-(viewport.offset.x / viewport.scale) * scale}
+      y={-(viewport.offset.y / viewport.scale) * scale}
       listening={false}
     >
       <Layer>

--- a/neo-modelo/src/canvas/nodes/AttributeNode.tsx
+++ b/neo-modelo/src/canvas/nodes/AttributeNode.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useState } from "react";
 import { Group, Circle, Text } from "react-konva";
 import { useERStore } from "@/core/store";
 import type { AttributeNode as A } from "@/core/types";
@@ -13,6 +13,8 @@ function AttributeNodeBase({ node, draggable = true, onStartConnect }: { node: A
   const connect = useERStore((s) => s.connect);
   const snap = useERStore((s) => s.settings.snap);
   const { theme } = useTheme();
+
+  const [hover, setHover] = useState(false);
 
   const R = 12;
 
@@ -36,6 +38,8 @@ function AttributeNodeBase({ node, draggable = true, onStartConnect }: { node: A
           setSelection([node.id]);
         }
       }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
     >
       <Circle
         radius={R}
@@ -59,7 +63,16 @@ function AttributeNodeBase({ node, draggable = true, onStartConnect }: { node: A
       />
 
       {[{x:0,y:-R},{x:R,y:0},{x:0,y:R},{x:-R,y:0}].map((a,i)=>(
-        <Circle key={i} x={a.x} y={a.y} radius={4} fill={theme === "dark" ? "#27272a" : "#fff"} stroke="#2563eb" onMouseDown={(e)=>{e.cancelBubble=true; onStartConnect?.(node.id,{x:node.pos.x + a.x,y:node.pos.y + a.y});}} />
+        <Circle
+          key={i}
+          x={a.x}
+          y={a.y}
+          radius={4}
+          visible={hover}
+          fill={theme === "dark" ? "#27272a" : "#fff"}
+          stroke="#2563eb"
+          onMouseDown={(e)=>{e.cancelBubble=true; onStartConnect?.(node.id,{x:node.pos.x + a.x,y:node.pos.y + a.y});}}
+        />
       ))}
     </Group>
   );

--- a/neo-modelo/src/canvas/nodes/EntityNode.tsx
+++ b/neo-modelo/src/canvas/nodes/EntityNode.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useState } from "react";
 import { Group, Rect, Text, Circle } from "react-konva";
 import { useERStore } from "@/core/store";
 import type { EntityNode as E } from "@/core/types";
@@ -14,6 +14,8 @@ function EntityNodeBase({ node, onContextMenu, draggable = true, onStartConnect 
   const connect = useERStore((s) => s.connect);
   const snap = useERStore((s) => s.settings.snap);
   const { theme } = useTheme();
+
+  const [hover, setHover] = useState(false);
 
   const W = Math.max(100, node.name.length * 9);
   const H = 50;
@@ -41,6 +43,8 @@ function EntityNodeBase({ node, onContextMenu, draggable = true, onStartConnect 
       onContextMenu={(e) => {
         onContextMenu?.(e);
       }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
     >
       <Rect
         x={-W/2}
@@ -75,7 +79,16 @@ function EntityNodeBase({ node, onContextMenu, draggable = true, onStartConnect 
       )}
 
       {[{x:0,y:-H/2},{x:W/2,y:0},{x:0,y:H/2},{x:-W/2,y:0}].map((a,i)=>(
-        <Circle key={i} x={a.x} y={a.y} radius={4} fill={theme === "dark" ? "#27272a" : "#fff"} stroke="#2563eb" onMouseDown={(e)=>{e.cancelBubble=true; onStartConnect?.(node.id,{x:node.pos.x + a.x,y:node.pos.y + a.y});}} />
+        <Circle
+          key={i}
+          x={a.x}
+          y={a.y}
+          radius={4}
+          visible={hover}
+          fill={theme === "dark" ? "#27272a" : "#fff"}
+          stroke="#2563eb"
+          onMouseDown={(e)=>{e.cancelBubble=true; onStartConnect?.(node.id,{x:node.pos.x + a.x,y:node.pos.y + a.y});}}
+        />
       ))}
     </Group>
   );

--- a/neo-modelo/src/canvas/nodes/RelationshipNode.tsx
+++ b/neo-modelo/src/canvas/nodes/RelationshipNode.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useState } from "react";
 import { Group, Line, Text, Circle } from "react-konva";
 import { useERStore } from "@/core/store";
 import type { RelationshipNode as R } from "@/core/types";
@@ -14,6 +14,8 @@ function RelationshipNodeBase({ node, onContextMenu, draggable = true, onStartCo
   const connect = useERStore((s) => s.connect);
   const snap = useERStore((s) => s.settings.snap);
   const { theme } = useTheme();
+
+  const [hover, setHover] = useState(false);
 
   const W = Math.max(120, node.name.length * 10);
   const H = W * 0.6;
@@ -42,6 +44,8 @@ function RelationshipNodeBase({ node, onContextMenu, draggable = true, onStartCo
       onContextMenu={(e) => {
         onContextMenu?.(e);
       }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
     >
       <Line
         points={diamond}
@@ -64,7 +68,16 @@ function RelationshipNodeBase({ node, onContextMenu, draggable = true, onStartCo
       {node.identifying && <Line points={diamond.map((v) => v * 0.9)} closed stroke={theme === "dark" ? "#e5e7eb" : "#111"} />}
 
       {[{x:0,y:-H/2},{x:W/2,y:0},{x:0,y:H/2},{x:-W/2,y:0}].map((a,i)=>(
-        <Circle key={i} x={a.x} y={a.y} radius={4} fill={theme === "dark" ? "#27272a" : "#fff"} stroke="#2563eb" onMouseDown={(e)=>{e.cancelBubble=true; onStartConnect?.(node.id,{x:node.pos.x + a.x,y:node.pos.y + a.y});}} />
+        <Circle
+          key={i}
+          x={a.x}
+          y={a.y}
+          radius={4}
+          visible={hover}
+          fill={theme === "dark" ? "#27272a" : "#fff"}
+          stroke="#2563eb"
+          onMouseDown={(e)=>{e.cancelBubble=true; onStartConnect?.(node.id,{x:node.pos.x + a.x,y:node.pos.y + a.y});}}
+        />
       ))}
     </Group>
   );

--- a/neo-modelo/src/index.css
+++ b/neo-modelo/src/index.css
@@ -47,32 +47,32 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
+  --background: oklch(0.22 0 0);
+  --foreground: oklch(0.96 0 0);
 
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
+  --muted: oklch(0.34 0 0);
+  --muted-foreground: oklch(0.78 0 0);
 
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.27 0 0);
+  --popover-foreground: oklch(0.96 0 0);
 
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
+  --card: oklch(0.27 0 0);
+  --card-foreground: oklch(0.96 0 0);
 
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
+  --border: oklch(1 0 0 / 15%);
+  --input: oklch(1 0 0 / 20%);
 
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
+  --primary: oklch(0.88 0 0);
+  --primary-foreground: oklch(0.22 0 0);
 
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.34 0 0);
+  --secondary-foreground: oklch(0.96 0 0);
 
-  --ring: oklch(0.556 0 0);
+  --ring: oklch(0.66 0 0);
 
-  --accent: oklch(0.269 0 0);
+  --accent: oklch(0.34 0 0);
 
-  --accent-foreground: oklch(0.985 0 0);
+  --accent-foreground: oklch(0.96 0 0);
 
   --destructive: oklch(0.704 0.191 22.216);
 
@@ -86,21 +86,21 @@
 
   --chart-5: oklch(0.645 0.246 16.439);
 
-  --sidebar: oklch(0.205 0 0);
+  --sidebar: oklch(0.27 0 0);
 
-  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.96 0 0);
 
-  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary: oklch(0.88 0 0);
 
-  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-primary-foreground: oklch(0.22 0 0);
 
-  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent: oklch(0.34 0 0);
 
-  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-accent-foreground: oklch(0.96 0 0);
 
-  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-border: oklch(1 0 0 / 15%);
 
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar-ring: oklch(0.66 0 0);
 }
 
 /* Utilitárias baseadas nas vars acima */

--- a/neo-modelo/src/ui/Toolbar.tsx
+++ b/neo-modelo/src/ui/Toolbar.tsx
@@ -25,7 +25,7 @@ export function Toolbar() {
   const zoom = (delta: number) => setViewport(viewport.scale * delta, viewport.offset);
 
   return (
-    <header className="h-14 w-full border-b border-border bg-background/60 backdrop-blur flex items-center px-4 py-2 gap-3">
+    <header className="h-14 w-full shadow-md bg-background/60 backdrop-blur flex items-center px-4 py-2 gap-3">
       <Button variant="outline" size="sm" onClick={() => spawn(addEntity)} className="gap-1">
         <Square className="h-4 w-4" /> Entity
       </Button>


### PR DESCRIPTION
## Summary
- hide node anchors until hover
- adjust minimap positioning and style
- soften dark theme and add toolbar shadow

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cb37d89f48328940d0888408bf2de